### PR TITLE
fix: help message list certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 *.pem
 cmd/cfd/*.yaml
 dist/
+
+# Exclude binary generated after go build
+cmd/cfd/cfd

--- a/cmd/cfd/cmd/cmd_list_certificates.go
+++ b/cmd/cfd/cmd/cmd_list_certificates.go
@@ -39,11 +39,11 @@ import (
 // listCertificateCmd represents the bootstrap command
 var listCertificateCmd = &cobra.Command{
 	Use:     "certificate",
-	Aliases: []string{"cert"},
-	Short:   "Deletes a certificate by its Common Name from the store",
-	Long: `Deletes a certificate by its Common Name from the store
-	
-Every CA is identified by a UUID. 
+	Aliases: []string{"cert", "certificates"},
+	Short:   "List certificates associated with the CA",
+	Long: `List certificates associated with the CA
+
+Every CA is identified by a UUID.
 
 The CA ID is required on each request.`,
 	Run: listCertificateFunc,


### PR DESCRIPTION
Fix: Help message of list certificates and added plural version as option

Added binary to .gitignore