### PR TITLE
Fixed #38: New global parameter URL

### DIFF
--- a/cmd/cfd/cmd/cmd_info_certificate.go
+++ b/cmd/cfd/cmd/cmd_info_certificate.go
@@ -39,7 +39,7 @@ var infoCertificateCmd = &cobra.Command{
 	Aliases: []string{"cert"},
 	Short:   "Show (friendly) information about a certificate.",
 	Long: `Show information about a certificate. Allows to get data from:
- 
+
   - File
   - Common Name
   - Remote URL
@@ -58,7 +58,7 @@ func init() {
 	infoCertificateCmd.Flags().StringVar(&global.collection, "ca-id", "", "CA Identifier. (required if --cn) [$CFD_CA_ID]")
 	infoCertificateCmd.Flags().StringVar(&global.cn, "cn", "", "Common name to query for information.")
 	infoCertificateCmd.Flags().StringVarP(&global.filename, "file", "f", "", "Source file with the certificate.")
-	infoCertificateCmd.Flags().StringVarP(&global.listen, "url", "u", "", "URL to get information from.")
+	infoCertificateCmd.Flags().StringVarP(&global.url, "url", "u", "", "URL to get information from.")
 	infoCertificateCmd.Flags().Int64Var(&timeout, "timeout", 5, "Timeout for network calls (only used if --url is especified).")
 	infoCertificateCmd.Flags().BoolVar(&insecure, "insecure", false, "Insecure allows skip verification of the server certificate (only used if --url is especified).")
 	infoCertificateCmd.Flags().BoolVar(&global.bool1, "markdown", false, "Return the data formatted as markdown.")
@@ -97,14 +97,16 @@ func infoCertificateFunc(cmd *cobra.Command, args []string) {
 			er(err)
 
 		} else {
-
-			if global.listen == "" {
+			if global.url == "" {
 				fmt.Println("Select the certificate to get its information")
+				fmt.Println()
+				// Print out the help information
+				cmd.Help()
 				os.Exit(1)
 			}
 
 			// if url getInfo.from URL()
-			certInfo, err = certinfo.NewFromURL(global.listen, timeout, insecure)
+			certInfo, err = certinfo.NewFromURL(global.url, timeout, insecure)
 			er(err)
 
 		}

--- a/cmd/cfd/cmd/constants.go
+++ b/cmd/cfd/cmd/constants.go
@@ -48,6 +48,7 @@ type globalConfig struct {
 	bool2       bool   // common bool option
 	remaining   int    // remaining percert (integer) for expiration
 	listen      string // webserver ip:port to listen
+	url         string // url to consult for certificates
 	root        string // webserver root
 	quiet       bool   // run in quiet mode
 	pfxFile     string // pfx file to save


### PR DESCRIPTION
<!--  Thank you for the Pull Request !!!  -->

Fixes #38 

**Description**
Created a new global to store the parameter `url` as listen gets prefilled with `0.0.0.0:8443`
I think specific globals should be used when possible to help readibility fo the code

<!-- Describe your changes here - ideally you can get that description straight from
your descriptive commit message(s)! -->


**Submitter Checklist**

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes unit tests.: CMD does not have unit tests
- [ ] Code coverage remains the same or better.

*See [the contribution guide](../CONTRIBUTING.md) for more details.*
