### PR TITLE
#40 fix badger db corruption on windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.17
 
       - 
         name: Test
@@ -64,7 +64,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.17
 
       -
         name: Run goreleaser - release

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # vendor/
 
 *.pem
+*.pfx
 cmd/cfd/*.yaml
 dist/
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,8 @@ builds:
     ignore:
       - goos: freebsd
         goarch: arm64
+      - goos: windows
+        goarch: arm64
       - goos: freebsd
         goarch: arm
     flags:

--- a/db/badger/badger.go
+++ b/db/badger/badger.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/dgraph-io/badger"
 	"github.com/fernandezvara/certsfor/db/store"
@@ -36,6 +37,10 @@ func (f Driver) Open(ctx context.Context, connection string) (store.Store, error
 	}
 
 	opts = badger.DefaultOptions(connection).WithSyncWrites(true)
+
+	if runtime.GOOS == "windows" {
+		opts = opts.WithTruncate(true)
+	}
 
 	store.db, err = badger.Open(opts)
 	if err != nil {

--- a/internal/manager/ca_test.go
+++ b/internal/manager/ca_test.go
@@ -346,7 +346,7 @@ nV3Z8XSWsFRPth5prC//U9OnGFAcKy9rHMtGR6vO1BuTdwWsNY+R0LQUJ3C1
 
 	assert.Nil(t, errCA)
 	assert.Error(t, err)
-	assert.Equal(t, "asn1: syntax error: data truncated", err.Error())
+	assert.Equal(t, "x509: malformed certificate", err.Error())
 
 	errCA, err = FromBytes([]byte(goodCert), []byte(badKey))
 
@@ -364,7 +364,7 @@ nV3Z8XSWsFRPth5prC//U9OnGFAcKy9rHMtGR6vO1BuTdwWsNY+R0LQUJ3C1
 
 	assert.Nil(t, errCA)
 	assert.Error(t, err)
-	assert.Equal(t, "asn1: syntax error: data truncated", err.Error())
+	assert.Equal(t, "x509: malformed certificate", err.Error())
 
 	errCA, err = FromBytes([]byte(badCert2), []byte(goodKey))
 


### PR DESCRIPTION
Fixes #40 

**Description**

On Windows systems, badger needs a flag for always truncating the DB files.
